### PR TITLE
feat: enable new `sample_ext` implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1911,8 +1911,8 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openvm"
-version = "1.0.0"
-source = "git+https://github.com/scroll-tech/openvm.git?branch=feat%2Fnative_multi_observe#6a19de9774e43cea77a1c30d9f1dab342966f28f"
+version = "1.1.0"
+source = "git+https://github.com/scroll-tech/openvm.git?branch=feat%2Fnative_multi_observe#3582ebf90d1a2aa1742912c46e1dedb5294904f1"
 dependencies = [
  "bytemuck",
  "num-bigint 0.4.6",
@@ -1924,8 +1924,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-circuit"
-version = "1.0.0"
-source = "git+https://github.com/scroll-tech/openvm.git?branch=feat%2Fnative_multi_observe#6a19de9774e43cea77a1c30d9f1dab342966f28f"
+version = "1.1.0"
+source = "git+https://github.com/scroll-tech/openvm.git?branch=feat%2Fnative_multi_observe#3582ebf90d1a2aa1742912c46e1dedb5294904f1"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -1955,8 +1955,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-circuit-derive"
-version = "1.0.0"
-source = "git+https://github.com/scroll-tech/openvm.git?branch=feat%2Fnative_multi_observe#6a19de9774e43cea77a1c30d9f1dab342966f28f"
+version = "1.1.0"
+source = "git+https://github.com/scroll-tech/openvm.git?branch=feat%2Fnative_multi_observe#3582ebf90d1a2aa1742912c46e1dedb5294904f1"
 dependencies = [
  "itertools 0.14.0",
  "quote",
@@ -1965,8 +1965,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-circuit-primitives"
-version = "1.0.0"
-source = "git+https://github.com/scroll-tech/openvm.git?branch=feat%2Fnative_multi_observe#6a19de9774e43cea77a1c30d9f1dab342966f28f"
+version = "1.1.0"
+source = "git+https://github.com/scroll-tech/openvm.git?branch=feat%2Fnative_multi_observe#3582ebf90d1a2aa1742912c46e1dedb5294904f1"
 dependencies = [
  "derive-new 0.6.0",
  "itertools 0.14.0",
@@ -1980,8 +1980,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-circuit-primitives-derive"
-version = "1.0.0"
-source = "git+https://github.com/scroll-tech/openvm.git?branch=feat%2Fnative_multi_observe#6a19de9774e43cea77a1c30d9f1dab342966f28f"
+version = "1.1.0"
+source = "git+https://github.com/scroll-tech/openvm.git?branch=feat%2Fnative_multi_observe#3582ebf90d1a2aa1742912c46e1dedb5294904f1"
 dependencies = [
  "itertools 0.14.0",
  "quote",
@@ -1991,7 +1991,7 @@ dependencies = [
 [[package]]
 name = "openvm-custom-insn"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/openvm.git?branch=feat%2Fnative_multi_observe#6a19de9774e43cea77a1c30d9f1dab342966f28f"
+source = "git+https://github.com/scroll-tech/openvm.git?branch=feat%2Fnative_multi_observe#3582ebf90d1a2aa1742912c46e1dedb5294904f1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2000,8 +2000,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-instructions"
-version = "1.0.0"
-source = "git+https://github.com/scroll-tech/openvm.git?branch=feat%2Fnative_multi_observe#6a19de9774e43cea77a1c30d9f1dab342966f28f"
+version = "1.1.0"
+source = "git+https://github.com/scroll-tech/openvm.git?branch=feat%2Fnative_multi_observe#3582ebf90d1a2aa1742912c46e1dedb5294904f1"
 dependencies = [
  "backtrace",
  "derive-new 0.6.0",
@@ -2017,8 +2017,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-instructions-derive"
-version = "1.0.0"
-source = "git+https://github.com/scroll-tech/openvm.git?branch=feat%2Fnative_multi_observe#6a19de9774e43cea77a1c30d9f1dab342966f28f"
+version = "1.1.0"
+source = "git+https://github.com/scroll-tech/openvm.git?branch=feat%2Fnative_multi_observe#3582ebf90d1a2aa1742912c46e1dedb5294904f1"
 dependencies = [
  "quote",
  "syn 2.0.101",
@@ -2026,8 +2026,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-native-circuit"
-version = "1.0.0"
-source = "git+https://github.com/scroll-tech/openvm.git?branch=feat%2Fnative_multi_observe#6a19de9774e43cea77a1c30d9f1dab342966f28f"
+version = "1.1.0"
+source = "git+https://github.com/scroll-tech/openvm.git?branch=feat%2Fnative_multi_observe#3582ebf90d1a2aa1742912c46e1dedb5294904f1"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -2053,8 +2053,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-native-compiler"
-version = "1.0.0"
-source = "git+https://github.com/scroll-tech/openvm.git?branch=feat%2Fnative_multi_observe#6a19de9774e43cea77a1c30d9f1dab342966f28f"
+version = "1.1.0"
+source = "git+https://github.com/scroll-tech/openvm.git?branch=feat%2Fnative_multi_observe#3582ebf90d1a2aa1742912c46e1dedb5294904f1"
 dependencies = [
  "backtrace",
  "itertools 0.14.0",
@@ -2075,8 +2075,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-native-compiler-derive"
-version = "1.0.0"
-source = "git+https://github.com/scroll-tech/openvm.git?branch=feat%2Fnative_multi_observe#6a19de9774e43cea77a1c30d9f1dab342966f28f"
+version = "1.1.0"
+source = "git+https://github.com/scroll-tech/openvm.git?branch=feat%2Fnative_multi_observe#3582ebf90d1a2aa1742912c46e1dedb5294904f1"
 dependencies = [
  "quote",
  "syn 2.0.101",
@@ -2084,8 +2084,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-native-recursion"
-version = "1.0.0"
-source = "git+https://github.com/scroll-tech/openvm.git?branch=feat%2Fnative_multi_observe#6a19de9774e43cea77a1c30d9f1dab342966f28f"
+version = "1.1.0"
+source = "git+https://github.com/scroll-tech/openvm.git?branch=feat%2Fnative_multi_observe#3582ebf90d1a2aa1742912c46e1dedb5294904f1"
 dependencies = [
  "cfg-if",
  "itertools 0.14.0",
@@ -2108,8 +2108,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-platform"
-version = "1.0.0"
-source = "git+https://github.com/scroll-tech/openvm.git?branch=feat%2Fnative_multi_observe#6a19de9774e43cea77a1c30d9f1dab342966f28f"
+version = "1.1.0"
+source = "git+https://github.com/scroll-tech/openvm.git?branch=feat%2Fnative_multi_observe#3582ebf90d1a2aa1742912c46e1dedb5294904f1"
 dependencies = [
  "getrandom 0.2.16",
  "libm",
@@ -2119,8 +2119,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-poseidon2-air"
-version = "1.0.0"
-source = "git+https://github.com/scroll-tech/openvm.git?branch=feat%2Fnative_multi_observe#6a19de9774e43cea77a1c30d9f1dab342966f28f"
+version = "1.1.0"
+source = "git+https://github.com/scroll-tech/openvm.git?branch=feat%2Fnative_multi_observe#3582ebf90d1a2aa1742912c46e1dedb5294904f1"
 dependencies = [
  "derivative",
  "lazy_static",
@@ -2136,8 +2136,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-rv32im-circuit"
-version = "1.0.0"
-source = "git+https://github.com/scroll-tech/openvm.git?branch=feat%2Fnative_multi_observe#6a19de9774e43cea77a1c30d9f1dab342966f28f"
+version = "1.1.0"
+source = "git+https://github.com/scroll-tech/openvm.git?branch=feat%2Fnative_multi_observe#3582ebf90d1a2aa1742912c46e1dedb5294904f1"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -2159,8 +2159,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-rv32im-guest"
-version = "1.0.0"
-source = "git+https://github.com/scroll-tech/openvm.git?branch=feat%2Fnative_multi_observe#6a19de9774e43cea77a1c30d9f1dab342966f28f"
+version = "1.1.0"
+source = "git+https://github.com/scroll-tech/openvm.git?branch=feat%2Fnative_multi_observe#3582ebf90d1a2aa1742912c46e1dedb5294904f1"
 dependencies = [
  "openvm-custom-insn",
  "strum_macros",
@@ -2168,8 +2168,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-rv32im-transpiler"
-version = "1.0.0"
-source = "git+https://github.com/scroll-tech/openvm.git?branch=feat%2Fnative_multi_observe#6a19de9774e43cea77a1c30d9f1dab342966f28f"
+version = "1.1.0"
+source = "git+https://github.com/scroll-tech/openvm.git?branch=feat%2Fnative_multi_observe#3582ebf90d1a2aa1742912c46e1dedb5294904f1"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -2244,8 +2244,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-transpiler"
-version = "1.0.0"
-source = "git+https://github.com/scroll-tech/openvm.git?branch=feat%2Fnative_multi_observe#6a19de9774e43cea77a1c30d9f1dab342966f28f"
+version = "1.1.0"
+source = "git+https://github.com/scroll-tech/openvm.git?branch=feat%2Fnative_multi_observe#3582ebf90d1a2aa1742912c46e1dedb5294904f1"
 dependencies = [
  "elf",
  "eyre",


### PR DESCRIPTION
# Summary
This PR is similar to #8 which itself is built on top of https://github.com/scroll-tech/openvm/pull/2.

Cycle count for verifying a sumcheck proof with `num_var = 5` and `max_deg = 3` before and after this pr is listed below.

cmd: `cargo test --features "bench-metrics" --release --lib test_simple_sumcheck -- --nocapture`.

- before (in PR #9): 1829
- after: 1634

That is, new `sample_ext` saves us about **40** cycles per variable.