### PR TITLE
feat: dot product when one vector's size is known

### DIFF
--- a/src/arithmetics/mod.rs
+++ b/src/arithmetics/mod.rs
@@ -122,6 +122,23 @@ pub fn dot_product_pt_n_eval<C: Config>(
     acc
 }
 
+pub fn fixed_dot_product<C: Config>(
+    builder: &mut Builder<C>,
+    a: &[Ext<C::F, C::EF>],
+    b: &Array<C, Ext<C::F, C::EF>>,
+    zero: Ext<C::F, C::EF>,
+) -> Ext<<C as Config>::F, <C as Config>::EF> {
+    // simple trick to prefer AddE(1 cycle) than AddEI(4 cycles)
+    let acc: Ext<C::F, C::EF> = builder.eval(zero + zero);
+
+    for (i, va) in a.iter().enumerate() {
+        let vb = builder.get(b, i);
+        builder.assign(&acc, acc + *va * vb);
+    }
+
+    acc
+}
+
 pub fn reverse<C: Config, T: MemVariable<C>>(
     builder: &mut Builder<C>,
     arr: &Array<C, T>,


### PR DESCRIPTION
## Rationale
Since number of elements in `coeffs = vec![1-r_merge, r_merge]` is known at the setup time, we don't need to use `Array` to store it. 

## Performance
This PR saves about 20 cycles.