### PR TITLE
Feat: extend array `rt` by `rt_merge`

### DIFF
--- a/src/arithmetics/mod.rs
+++ b/src/arithmetics/mod.rs
@@ -238,29 +238,21 @@ pub fn sum<C: Config>(
     acc
 }
 
-// Join two arrays
-pub fn join<C: Config>(
+// Extend an array by one element
+pub fn extend<C: Config>(
     builder: &mut Builder<C>,
-    a: &Array<C, Ext<C::F, C::EF>>,
-    b: &Array<C, Ext<C::F, C::EF>>,
+    arr: &Array<C, Ext<C::F, C::EF>>,
+    elem: &Ext<C::F, C::EF>,
 ) -> Array<C, Ext<C::F, C::EF>> {
-    let a_len = a.len();
-    let b_len = b.len();
-    let out_len = builder.eval_expr(a_len.clone() + b_len.clone());
-    let out = builder.dyn_array(out_len);
+    let new_len: Var<C::N> = builder.eval(arr.len() + C::N::ONE);
+    let out = builder.dyn_array(new_len);
 
-    builder.range(0, a_len.clone()).for_each(|i_vec, builder| {
+    builder.range(0, arr.len()).for_each(|i_vec, builder| {
         let i = i_vec[0];
-        let a_val = builder.get(a, i);
-        builder.set(&out, i, a_val);
+        let val = builder.get(arr, i);
+        builder.set_value(&out, i, val);
     });
-
-    builder.range(0, b_len).for_each(|i_vec, builder| {
-        let b_i = i_vec[0];
-        let i = builder.eval_expr(b_i + a_len.clone());
-        let b_val = builder.get(b, b_i);
-        builder.set(&out, i, b_val);
-    });
+    builder.set_value(&out, arr.len(), elem.clone());
 
     out
 }

--- a/src/tower_verifier/program.rs
+++ b/src/tower_verifier/program.rs
@@ -2,7 +2,8 @@ use super::binding::{
     IOPProverMessageVariable, PointAndEvalVariable, PointVariable, TowerVerifierInputVariable,
 };
 use crate::arithmetics::{
-    challenger_multi_observe, dot_product, dot_product_pt_n_eval, eq_eval, evaluate_at_point, exts_to_felts, fixed_dot_product, gen_alpha_pows, is_smaller_than, join, product, reverse
+    challenger_multi_observe, dot_product, dot_product_pt_n_eval, eq_eval, evaluate_at_point,
+    extend, exts_to_felts, fixed_dot_product, gen_alpha_pows, is_smaller_than, product, reverse,
 };
 use crate::transcript::transcript_observe_label;
 use openvm_native_compiler::prelude::*;
@@ -444,9 +445,7 @@ pub fn verify_tower_proof<C: Config>(
             let c2: Ext<<C as Config>::F, <C as Config>::EF> = builder.eval(r_merge.clone());
             let coeffs = vec![c1, c2];
 
-            let r_merge_arr = builder.dyn_array(RVar::from(1));
-            builder.set(&r_merge_arr, 0, r_merge);
-            let rt_prime = join(builder, &sub_rt, &r_merge_arr);
+            let rt_prime = extend(builder, &sub_rt, &r_merge);
             builder.cycle_tracker_end("derive rt_prime");
 
             // generate next round challenge


### PR DESCRIPTION
## Rationale

Extend the array `rt` by one element `rt_merge`.

## Performance

This PR saves about 40 cycles.