### PR TITLE
Feat: compute powers of `alpha` on the fly

### DIFF
--- a/src/arithmetics/mod.rs
+++ b/src/arithmetics/mod.rs
@@ -104,24 +104,6 @@ pub fn dot_product<C: Config>(
     acc
 }
 
-pub fn dot_product_pt_n_eval<C: Config>(
-    builder: &mut Builder<C>,
-    pt_and_eval: &Array<C, PointAndEvalVariable<C>>,
-    b: &Array<C, Ext<C::F, C::EF>>,
-) -> Ext<<C as Config>::F, <C as Config>::EF> {
-    let acc: Ext<C::F, C::EF> = builder.eval(C::F::ZERO);
-
-    iter_zip!(builder, pt_and_eval, b).for_each(|idx_vec, builder| {
-        let ptr_a = idx_vec[0];
-        let ptr_b = idx_vec[1];
-        let v_a = builder.iter_ptr_get(&pt_and_eval, ptr_a);
-        let v_b = builder.iter_ptr_get(&b, ptr_b);
-        builder.assign(&acc, acc + v_a.eval * v_b);
-    });
-
-    acc
-}
-
 pub fn fixed_dot_product<C: Config>(
     builder: &mut Builder<C>,
     a: &[Ext<C::F, C::EF>],

--- a/src/tower_verifier/program.rs
+++ b/src/tower_verifier/program.rs
@@ -398,14 +398,12 @@ pub fn verify_tower_proof<C: Config>(
                     builder.cycle_tracker_end("accumulate expected eval for prod specs");
                 });
 
-            builder.cycle_tracker_start("cleanup");
             let num_variables_len = tower_verifier_input.num_variables.len();
             let logup_num_variables_slice = tower_verifier_input.num_variables.slice(
                 builder,
                 num_prod_spec.clone(),
                 num_variables_len.clone(),
             );
-            builder.cycle_tracker_end("cleanup");
 
             builder
                 .range(0, num_logup_spec.clone())

--- a/src/tower_verifier/program.rs
+++ b/src/tower_verifier/program.rs
@@ -2,8 +2,8 @@ use super::binding::{
     IOPProverMessageVariable, PointAndEvalVariable, PointVariable, TowerVerifierInputVariable,
 };
 use crate::arithmetics::{
-    challenger_multi_observe, dot_product, dot_product_pt_n_eval, eq_eval, evaluate_at_point,
-    extend, exts_to_felts, fixed_dot_product, gen_alpha_pows, is_smaller_than, product, reverse,
+    challenger_multi_observe, eq_eval, evaluate_at_point,
+    extend, exts_to_felts, fixed_dot_product, is_smaller_than, product, reverse,
 };
 use crate::transcript::transcript_observe_label;
 use openvm_native_compiler::prelude::*;


### PR DESCRIPTION
## Performance

Summary: we have about 20% improvement. And the performance gain is due to two parts:
1. avoid computing `eq(rt, sub_rt)` in several places.
2. compute $\alpha$'s powers on the fly.

The cycle count after this PR:

```
INFO     ┝━ ｉ [info]: ┌╴initial sum
INFO     ┝━ ｉ [info]: └╴162 cycles
INFO     ┝━ ｉ [info]: ┌╴check expected evaluation
INFO     ┝━ ｉ [info]: └╴171 cycles
INFO     ┝━ ｉ [info]: ┌╴derive next layer's expected sum
INFO     ┝━ ｉ [info]: └╴287 cycles
INFO     ┝━ ｉ [info]: ┌╴check expected evaluation
INFO     ┝━ ｉ [info]: └╴186 cycles
INFO     ┝━ ｉ [info]: ┌╴derive next layer's expected sum
INFO     ┝━ ｉ [info]: └╴295 cycles
INFO     ┝━ ｉ [info]: ┌╴check expected evaluation
INFO     ┝━ ｉ [info]: └╴201 cycles
INFO     ┝━ ｉ [info]: ┌╴derive next layer's expected sum
INFO     ┝━ ｉ [info]: └╴303 cycles
INFO     ┝━ ｉ [info]: ┌╴check expected evaluation
INFO     ┝━ ｉ [info]: └╴216 cycles
INFO     ┝━ ｉ [info]: ┌╴derive next layer's expected sum
INFO     ┕━ ｉ [info]: └╴305 cycles
```

The cycle count before this PR:
```
INFO     ┝━ ｉ [info]: ┌╴initial sum
INFO     ┝━ ｉ [info]: └╴183 cycles
INFO     ┝━ ｉ [info]: ┌╴check expected evaluation
INFO     ┝━ ｉ [info]: └╴216 cycles
INFO     ┝━ ｉ [info]: ┌╴derive next layer's expected sum
INFO     ┝━ ｉ [info]: └╴360 cycles
INFO     ┝━ ｉ [info]: ┌╴check expected evaluation
INFO     ┝━ ｉ [info]: └╴254 cycles
INFO     ┝━ ｉ [info]: ┌╴derive next layer's expected sum
INFO     ┝━ ｉ [info]: └╴368 cycles
INFO     ┝━ ｉ [info]: ┌╴check expected evaluation
INFO     ┝━ ｉ [info]: └╴292 cycles
INFO     ┝━ ｉ [info]: ┌╴derive next layer's expected sum
INFO     ┝━ ｉ [info]: └╴376 cycles
INFO     ┝━ ｉ [info]: ┌╴check expected evaluation
INFO     ┝━ ｉ [info]: └╴330 cycles
INFO     ┝━ ｉ [info]: ┌╴derive next layer's expected sum
INFO     ┕━ ｉ [info]: └╴378 cycles
```