### PR TITLE
Feat: optimize `extrapolate_uni_poly`

### DIFF
--- a/src/arithmetics/mod.rs
+++ b/src/arithmetics/mod.rs
@@ -761,8 +761,8 @@ impl<C: Config> UniPolyExtrapolator<C> {
         let p_i_0 = builder.get(p_i, 0);
         let p_i_1 = builder.get(p_i, 1);
 
-        let t0: Ext<C::F, C::EF> = builder.eval(self.constants[5] * p_i_0 * d0.inverse());
-        let t1: Ext<C::F, C::EF> = builder.eval(self.constants[1] * p_i_1 * d1.inverse());
+        let t0: Ext<C::F, C::EF> = builder.eval(self.constants[5] * p_i_0 / d0);
+        let t1: Ext<C::F, C::EF> = builder.eval(self.constants[1] * p_i_1 / d1);
 
         builder.eval(l * (t0 + t1))
     }
@@ -781,9 +781,9 @@ impl<C: Config> UniPolyExtrapolator<C> {
         let p_i_1: Ext<C::F, C::EF> = builder.get(p_i, 1);
         let p_i_2: Ext<C::F, C::EF> = builder.get(p_i, 2);
 
-        let t0: Ext<C::F, C::EF> = builder.eval(self.constants[6] * p_i_0 * d0.inverse());
-        let t1: Ext<C::F, C::EF> = builder.eval(self.constants[5] * p_i_1 * d1.inverse());
-        let t2: Ext<C::F, C::EF> = builder.eval(self.constants[6] * p_i_2 * d2.inverse());
+        let t0: Ext<C::F, C::EF> = builder.eval(self.constants[6] * p_i_0 / d0);
+        let t1: Ext<C::F, C::EF> = builder.eval(self.constants[5] * p_i_1 / d1);
+        let t2: Ext<C::F, C::EF> = builder.eval(self.constants[6] * p_i_2 / d2);
 
         builder.eval(l * (t0 + t1 + t2))
     }
@@ -805,10 +805,10 @@ impl<C: Config> UniPolyExtrapolator<C> {
         let p_i_2: Ext<C::F, C::EF> = builder.get(p_i, 2);
         let p_i_3: Ext<C::F, C::EF> = builder.get(p_i, 3);
 
-        let t0: Ext<C::F, C::EF> = builder.eval(self.constants[9] * p_i_0 * d0.inverse());
-        let t1: Ext<C::F, C::EF> = builder.eval(self.constants[6] * p_i_1 * d1.inverse());
-        let t2: Ext<C::F, C::EF> = builder.eval(self.constants[7] * p_i_2 * d2.inverse());
-        let t3: Ext<C::F, C::EF> = builder.eval(self.constants[8] * p_i_3 * d3.inverse());
+        let t0: Ext<C::F, C::EF> = builder.eval(self.constants[9] * p_i_0 / d0);
+        let t1: Ext<C::F, C::EF> = builder.eval(self.constants[6] * p_i_1 / d1);
+        let t2: Ext<C::F, C::EF> = builder.eval(self.constants[7] * p_i_2 / d2);
+        let t3: Ext<C::F, C::EF> = builder.eval(self.constants[8] * p_i_3 / d3);
 
         builder.eval(l * (t0 + t1 + t2 + t3))
     }
@@ -833,11 +833,11 @@ impl<C: Config> UniPolyExtrapolator<C> {
         let p_i_3: Ext<C::F, C::EF> = builder.get(p_i, 3);
         let p_i_4: Ext<C::F, C::EF> = builder.get(p_i, 4);
 
-        let t0: Ext<C::F, C::EF> = builder.eval(self.constants[11] * p_i_0 * d0.inverse());
-        let t1: Ext<C::F, C::EF> = builder.eval(self.constants[9] * p_i_1 * d1.inverse());
-        let t2: Ext<C::F, C::EF> = builder.eval(self.constants[10] * p_i_2 * d2.inverse());
-        let t3: Ext<C::F, C::EF> = builder.eval(self.constants[9] * p_i_3 * d3.inverse());
-        let t4: Ext<C::F, C::EF> = builder.eval(self.constants[11] * p_i_4 * d4.inverse());
+        let t0: Ext<C::F, C::EF> = builder.eval(self.constants[11] * p_i_0 / d0);
+        let t1: Ext<C::F, C::EF> = builder.eval(self.constants[9] * p_i_1 / d1);
+        let t2: Ext<C::F, C::EF> = builder.eval(self.constants[10] * p_i_2 / d2);
+        let t3: Ext<C::F, C::EF> = builder.eval(self.constants[9] * p_i_3 / d3);
+        let t4: Ext<C::F, C::EF> = builder.eval(self.constants[11] * p_i_4 / d4);
 
         builder.eval(l * (t0 + t1 + t2 + t3 + t4))
     }


### PR DESCRIPTION
## Rationale

Prefer division of `a` by `x` than `a * x.inverse()` as `inverse()` is equivalent to `a * one / x`.

## Performance
The cycle count of `fn extrapolate_uni_poly` for degree = 3 before and after the PR is listed below:
- before: 52
- after: 32

The cycle count in sumcheck verifier for 5 variables and degree = 3 is reduced from 615 to 515. Therefore the per variable cost is reduced from 123 to 103 (20% improvement).

The raw log is
```
INFO     ┝━ ｉ [info]: ┌╴sumcheck verify
INFO     ┝━ ｉ [info]: │ ┌╴IOPVerifierState::verify_round_and_update_state
INFO     ┝━ ｉ [info]: │ │ ┌╴observe_then_sample
INFO     ┝━ ｉ [info]: │ │ └╴45 cycles
INFO     ┝━ ｉ [info]: │ │ ┌╴extrapolate_uni_poly
INFO     ┝━ ｉ [info]: │ │ └╴32 cycles
INFO     ┝━ ｉ [info]: │ │ ┌╴observe_then_sample
INFO     ┝━ ｉ [info]: │ │ └╴44 cycles
INFO     ┝━ ｉ [info]: │ │ ┌╴extrapolate_uni_poly
INFO     ┝━ ｉ [info]: │ │ └╴32 cycles
INFO     ┝━ ｉ [info]: │ │ ┌╴observe_then_sample
INFO     ┝━ ｉ [info]: │ │ └╴44 cycles
INFO     ┝━ ｉ [info]: │ │ ┌╴extrapolate_uni_poly
INFO     ┝━ ｉ [info]: │ │ └╴32 cycles
INFO     ┝━ ｉ [info]: │ │ ┌╴observe_then_sample
INFO     ┝━ ｉ [info]: │ │ └╴44 cycles
INFO     ┝━ ｉ [info]: │ │ ┌╴extrapolate_uni_poly
INFO     ┝━ ｉ [info]: │ │ └╴32 cycles
INFO     ┝━ ｉ [info]: │ │ ┌╴observe_then_sample
INFO     ┝━ ｉ [info]: │ │ └╴44 cycles
INFO     ┝━ ｉ [info]: │ │ ┌╴extrapolate_uni_poly
INFO     ┝━ ｉ [info]: │ │ └╴32 cycles
INFO     ┝━ ｉ [info]: │ └╴490 cycles
INFO     ┕━ ｉ [info]: └╴515 cycles
```
