### PR TITLE
Feat: generate stark in e2e test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,4 +45,4 @@ jobs:
       run: ./scripts/e2e_test.sh
 
     - name: Run unit tests
-      run: cargo test --all-features -- --nocapture
+      run: cargo test --release --all-features -- --nocapture

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Disable Lint
+
+  # Lint:
+  #   runs-on: ubuntu-latest
+
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   - name: Install stable Rust
+  #     uses: actions-rs/toolchain@v1
+  #     with:
+  #       toolchain: stable
+  #       components: rustfmt, clippy
+
+  #   - name: Fmt
+  #     run: cargo fmt --check
+
+  #   - name: Clippy
+  #     run: cargo clippy -- -D warnings
+
+  Test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install stable Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        components: clippy
+
+    - name: Run e2e test
+      run: ./scripts/e2e_test.sh
+
+    - name: Run unit tests
+      run: cargo test --all-features -- --nocapture

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ vm_run_output.log
 *.bin
 .DS_Store
 *.log
+build/ceno

--- a/scripts/e2e_test.sh
+++ b/scripts/e2e_test.sh
@@ -16,6 +16,8 @@ RUST_LOG=info cargo run --release --package ceno_zkvm --bin e2e -- --platform=ce
     --hints=10 --public-io=4191 examples/target/riscv32im-ceno-zkvm-elf/release/examples/fibonacci \
     --field=baby-bear
 
+mkdir -p $REPO_ROOT/src/e2e/encoded
+
 # Copy vk.bin and proof.bin to the src/e2e/encoded directory in the parent directory
 cp vk.bin $REPO_ROOT/src/e2e/encoded/
 cp proof.bin $REPO_ROOT/src/e2e/encoded/

--- a/scripts/e2e_test.sh
+++ b/scripts/e2e_test.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+
+# Clone the ceno repository if it doesn't exist
+if [ ! -d "$REPO_ROOT/build/ceno" ] || [ -z "$(ls -A "$REPO_ROOT/build/ceno" 2>/dev/null)" ]; then
+    git clone https://github.com/scroll-tech/ceno.git "$REPO_ROOT/build/ceno/"
+fi
+
+# Enter the ceno directory
+cd $REPO_ROOT/build/ceno && git checkout build/smaller_field_support_plonky3_539bbc
+
+# Execute the ceno_zkvm e2e test
+RUST_LOG=info cargo run --release --package ceno_zkvm --bin e2e -- --platform=ceno \
+    --hints=10 --public-io=4191 examples/target/riscv32im-ceno-zkvm-elf/release/examples/fibonacci \
+    --field=baby-bear
+
+# Copy vk.bin and proof.bin to the src/e2e/encoded directory in the parent directory
+cp vk.bin $REPO_ROOT/src/e2e/encoded/
+cp proof.bin $REPO_ROOT/src/e2e/encoded/
+
+# Return to the root directory
+cd $REPO_ROOT
+
+# Execute the test_zkvm_proof_verifier test
+RUST_LOG=info cargo test --release --lib test_zkvm_proof_verifier -- --nocapture


### PR DESCRIPTION
## Summary
In this pr, 

1. we add a script to run the e2e test that generates STARK to verify Ceno proof of $\textrm{fib}(2^{10}) = 4191$.
    The cmd to run it is `bash ./scripts/e2e_test.sh`.
2. we add a CI job to run the e2e test and also all unit tests.

## TODO

- [ ] use `log_blowup = 1` when we reduce max constraint degree from 4 to 3 in https://github.com/scroll-tech/openvm/pull/5.