### PR TITLE
Chore: make CI output more concise

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,22 +11,21 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Disable Lint
+  Lint:
+    runs-on: ubuntu-latest
 
-  # Lint:
-  #   runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install stable Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        components: rustfmt, clippy
 
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #   - name: Install stable Rust
-  #     uses: actions-rs/toolchain@v1
-  #     with:
-  #       toolchain: stable
-  #       components: rustfmt, clippy
+    - name: Fmt
+      run: cargo fmt --check
 
-  #   - name: Fmt
-  #     run: cargo fmt --check
-
+  # TODO: enable clippy later
   #   - name: Clippy
   #     run: cargo clippy -- -D warnings
 

--- a/scripts/e2e_test.sh
+++ b/scripts/e2e_test.sh
@@ -25,5 +25,5 @@ cp proof.bin $REPO_ROOT/src/e2e/encoded/
 # Return to the root directory
 cd $REPO_ROOT
 
-# Execute the test_zkvm_proof_verifier test
-RUST_LOG=info cargo test --release --lib test_zkvm_proof_verifier -- --nocapture
+# Execute the test_zkvm_verifier test
+RUST_LOG=info,p3_=warn cargo test --release --lib test_zkvm_verifier -- --nocapture

--- a/src/e2e/mod.rs
+++ b/src/e2e/mod.rs
@@ -1,19 +1,19 @@
 use crate::basefold_verifier::basefold::BasefoldCommitment;
 use crate::tower_verifier::binding::IOPProverMessage;
-use crate::zkvm_verifier::binding::{TowerProofInput, ZKVMProofInput, ZKVMChipProofInput, E, F};
+use crate::zkvm_verifier::binding::{TowerProofInput, ZKVMChipProofInput, ZKVMProofInput, E, F};
 use crate::zkvm_verifier::verifier::verify_zkvm_proof;
 
-use mpcs::{Basefold, BasefoldRSParams};
 use ceno_zkvm::scheme::ZKVMProof;
 use ceno_zkvm::structs::ZKVMVerifyingKey;
+use mpcs::{Basefold, BasefoldRSParams};
 
-use openvm_native_recursion::hints::Hintable;
 use openvm_circuit::arch::instructions::program::Program;
 use openvm_native_compiler::{
     asm::AsmBuilder,
     conversion::{convert_program, CompilerOptions},
     prelude::AsmCompiler,
 };
+use openvm_native_recursion::hints::Hintable;
 
 pub fn parse_zkvm_proof_import(
     zkvm_proof: ZKVMProof<E, Basefold<E, BasefoldRSParams>>,
@@ -208,7 +208,10 @@ pub fn build_zkvm_verifier_program(
     builder.halt();
 
     // Compile program
+    #[cfg(feature = "bench-metrics")]
     let options = CompilerOptions::default().with_cycle_tracker();
+    #[cfg(not(feature = "bench-metrics"))]
+    let options = CompilerOptions::default();
     let mut compiler = AsmCompiler::new(options.word_size);
     compiler.build(builder.operations);
     let asm_code = compiler.code();


### PR DESCRIPTION
1. By setting `RUST_LOG=info,p3_=warn` we get rid of the logs outputed by plonky3.
2. Output cycle distribution whenever we enable the feature `bench-metrics`.